### PR TITLE
Fix build and runtime for DESMO-J sample

### DIFF
--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/AirportModel.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/AirportModel.java
@@ -10,9 +10,9 @@ public class AirportModel extends Model {
     public final double LAMBDA_T1, LAMBDA_T2, LAMBDA_RS;
 
     /* Resources & queues */
-    public ProcessQueue<Passenger> qT1;
-    public ProcessQueue<Passenger> qT2;
-    public ProcessQueue<Passenger> qRS;
+    public Queue<Passenger> qT1;
+    public Queue<Passenger> qT2;
+    public Queue<Passenger> qRS;
 
     /* Distributions */
     public ContDistExponential distT1;
@@ -34,9 +34,9 @@ public class AirportModel extends Model {
     @Override
     public void init() {
         /* Queues */
-        qT1 = new ProcessQueue<>(this, "Queue T1", true, true);
-        qT2 = new ProcessQueue<>(this, "Queue T2", true, true);
-        qRS = new ProcessQueue<>(this, "Queue RS", true, true);
+        qT1 = new Queue<>(this, "Queue T1", true, true);
+        qT2 = new Queue<>(this, "Queue T2", true, true);
+        qRS = new Queue<>(this, "Queue RS", true, true);
 
         /* λ is passengers/hour, DESMO-J works with hours as default time unit */
         distT1 = new ContDistExponential(this, "IA T1", 1.0 / LAMBDA_T1, true, true);

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/AirportRentalSimulationDesmo.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/AirportRentalSimulationDesmo.java
@@ -1,12 +1,9 @@
 package com.example.airportdesmo;
 
 import desmoj.core.simulator.Experiment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AirportRentalSimulationDesmo {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AirportRentalSimulationDesmo.class);
 
     public static void main(String[] args) {
         double hours = 80;
@@ -15,15 +12,16 @@ public class AirportRentalSimulationDesmo {
         }
 
         Experiment exp = new Experiment("AirportSim-Desmo");
+        exp.setShowProgressBar(false);
         AirportModel model = new AirportModel(hours, 10, 8, 9, exp);
 
         exp.stop(new desmoj.core.simulator.TimeInstant(hours)); // stop after given hours
-        exp.traceOff(); // keep console clean – enable if needed
+        exp.traceOff(new desmoj.core.simulator.TimeInstant(0)); // disable tracing
         exp.start();
 
         exp.report();
         exp.finish();
 
-        LOG.info("Simulation finished after {} hours.", hours);
+        System.out.println("Simulation finished after " + hours + " hours.");
     }
 }

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/BusProcess.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/BusProcess.java
@@ -16,7 +16,7 @@ public class BusProcess extends SimProcess {
     }
 
     @Override
-    public void lifeCycle() {
+    public void lifeCycle() throws co.paralleluniverse.fibers.SuspendExecution {
         AirportModel model = (AirportModel) getModel();
 
         while (presentTime().getTimeAsDouble() < model.SIM_HOURS) {
@@ -31,7 +31,7 @@ public class BusProcess extends SimProcess {
             });
 
             /* 2. Board */
-            ProcessQueue<Passenger> queue = switch (currentStation) {
+            Queue<Passenger> queue = switch (currentStation) {
                 case T1 -> model.qT1;
                 case T2 -> model.qT2;
                 case RS -> model.qRS;

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/PassengerGenerator.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/PassengerGenerator.java
@@ -2,15 +2,17 @@ package com.example.airportdesmo;
 
 import desmoj.core.dist.ContDistExponential;
 import desmoj.core.simulator.*;
+import java.util.Random;
 
 public class PassengerGenerator extends SimProcess {
 
-    private final ProcessQueue<Passenger> myQueue;
+    private final Queue<Passenger> myQueue;
     private final ContDistExponential interArrival;
     private final Station origin;
+    private final Random rng = new Random(42);
 
     public PassengerGenerator(Model owner, String name, boolean trace,
-                              ProcessQueue<Passenger> queue,
+                              Queue<Passenger> queue,
                               ContDistExponential ia,
                               Station origin) {
         super(owner, name, trace);
@@ -20,12 +22,12 @@ public class PassengerGenerator extends SimProcess {
     }
 
     @Override
-    public void lifeCycle() {
+    public void lifeCycle() throws co.paralleluniverse.fibers.SuspendExecution {
         AirportModel model = (AirportModel) getModel();
         while (presentTime().getTimeAsDouble() < model.SIM_HOURS) {
             /* Create passenger */
             Station dest = (origin == Station.RS)
-                    ? (model.random().nextBoolean() ? Station.T1 : Station.T2)
+                    ? (rng.nextBoolean() ? Station.T1 : Station.T2)
                     : Station.RS;
 
             Passenger p = new Passenger(model, "Pax", false, origin, dest, presentTime().getTimeAsDouble());


### PR DESCRIPTION
## Summary
- adjust passenger queues to use `Queue` instead of `ProcessQueue`
- replace SLF4J logging with `System.out`
- provide deterministic RNG and declare SuspendExecution on processes
- turn off progress bar for headless environment
- compile and run simulation to completion

## Testing
- `javac -cp lib/desmoj-2.5.1e-bin.jar -d out $(find src/main/java -name '*.java')`
- `java -cp lib/desmoj-2.5.1e-bin.jar:out com.example.airportdesmo.AirportRentalSimulationDesmo | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684c1fb80b5883308037abb6630e6818