### PR TITLE
Enhance shuttle simulation with stats and dwell logic

### DIFF
--- a/airport-rental-sim-desmo (2)/README.md
+++ b/airport-rental-sim-desmo (2)/README.md
@@ -1,7 +1,9 @@
 # Airport Rental Shuttle – DESMO‑J Version
 
-A minimal discrete‑event simulation of a 20‑seat shuttle circulating  
+A minimal discrete‑event simulation of a 20‑seat shuttle circulating
 **RS → T1 → T2 → RS** using the **DESMO‑J** library.
+The bus waits at least five minutes at each stop and departs immediately once
+no boarding/alighting occurs.
 
 ## Build & Run
 
@@ -16,9 +18,9 @@ java -jar target/airport-rental-sim-desmo-1.0.0-jar-with-dependencies.jar --hour
 | Component | Implementation |
 |-----------|----------------|
 | Passenger arrivals | `PassengerGenerator` (one per station) with exponential inter‑arrival times |
-| Shuttle bus | `BusProcess` looping through the three stations, enforcing 5 min dwell & travel times |
-| Queues | `ProcessQueue<Passenger>` per station |
-| Metrics | For brevity this skeleton just prints DESMO‑J’s standard report; extend with `Tally` etc. as needed. |
+| Shuttle bus | `BusProcess` looping through the stations with dynamic dwell logic (≥5 min) |
+| Queues | `Queue<Passenger>` per station |
+| Metrics | Various `Tally`/`Accumulate` stats for waits, queue lengths, bus rounds, dwell times, and system time |
 
 The model is intentionally compact (≈250 LOC) to highlight how DESMO‑J replaces the custom event loop.  
 Feel free to extend capacities, add multiple buses, or collect additional statistics.

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/AirportModel.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/AirportModel.java
@@ -2,6 +2,7 @@ package com.example.airportdesmo;
 
 import desmoj.core.simulator.*;
 import desmoj.core.dist.*;
+import desmoj.core.statistic.*;
 
 public class AirportModel extends Model {
 
@@ -18,6 +19,15 @@ public class AirportModel extends Model {
     public ContDistExponential distT1;
     public ContDistExponential distT2;
     public ContDistExponential distRS;
+
+    /* Statistics */
+    public Accumulate qLenT1, qLenT2, qLenRS;
+    public long maxQT1 = 0, maxQT2 = 0, maxQRS = 0;
+    public Tally waitT1, waitT2, waitRS;
+    public Tally systemT1, systemT2, systemRS;
+    public Tally busOccupancy;
+    public Tally roundDurations;
+    public Tally dwellRS, dwellT1, dwellT2;
 
     public AirportModel(double simHours, double lT1, double lT2, double lRS, Experiment exp) {
         super(null, "Airport Rental Model", true, true);
@@ -38,6 +48,24 @@ public class AirportModel extends Model {
         qT2 = new Queue<>(this, "Queue T2", true, true);
         qRS = new Queue<>(this, "Queue RS", true, true);
 
+        qLenT1 = new Accumulate(this, "Len T1", 0.0, true, true);
+        qLenT2 = new Accumulate(this, "Len T2", 0.0, true, true);
+        qLenRS = new Accumulate(this, "Len RS", 0.0, true, true);
+
+        waitT1 = new Tally(this, "Wait T1", true, true);
+        waitT2 = new Tally(this, "Wait T2", true, true);
+        waitRS = new Tally(this, "Wait RS", true, true);
+
+        systemT1 = new Tally(this, "Sys T1", true, true);
+        systemT2 = new Tally(this, "Sys T2", true, true);
+        systemRS = new Tally(this, "Sys RS", true, true);
+
+        busOccupancy = new Tally(this, "Bus Occ", true, true);
+        roundDurations = new Tally(this, "Round Dur", true, true);
+        dwellRS = new Tally(this, "Dwell RS", true, true);
+        dwellT1 = new Tally(this, "Dwell T1", true, true);
+        dwellT2 = new Tally(this, "Dwell T2", true, true);
+
         /* λ is passengers/hour, DESMO-J works with hours as default time unit */
         distT1 = new ContDistExponential(this, "IA T1", 1.0 / LAMBDA_T1, true, true);
         distT2 = new ContDistExponential(this, "IA T2", 1.0 / LAMBDA_T2, true, true);
@@ -47,6 +75,10 @@ public class AirportModel extends Model {
         distT1.setSeed(42);
         distT2.setSeed(43);
         distRS.setSeed(44);
+
+        qLenT1.update(0);
+        qLenT2.update(0);
+        qLenRS.update(0);
     }
 
     @Override

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/BusProcess.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/BusProcess.java
@@ -19,12 +19,20 @@ public class BusProcess extends SimProcess {
     public void lifeCycle() throws co.paralleluniverse.fibers.SuspendExecution {
         AirportModel model = (AirportModel) getModel();
 
+        double lastRound = presentTime().getTimeAsDouble();
         while (presentTime().getTimeAsDouble() < model.SIM_HOURS) {
+
+            double arriveTime = presentTime().getTimeAsDouble();
 
             /* 1. Alight */
             onBoard.removeIf(p -> {
                 if (p.getDestination() == currentStation) {
                     p.alighted(presentTime().getTimeAsDouble());
+                    switch (p.getOrigin()) {
+                        case T1 -> model.systemT1.update(p.getSystemTime());
+                        case T2 -> model.systemT2.update(p.getSystemTime());
+                        case RS -> model.systemRS.update(p.getSystemTime());
+                    }
                     return true;
                 }
                 return false;
@@ -42,10 +50,61 @@ public class BusProcess extends SimProcess {
                 queue.remove(p);
                 p.boarded(presentTime().getTimeAsDouble());
                 onBoard.add(p);
+                switch (currentStation) {
+                    case T1 -> model.waitT1.update(p.getQueueWait());
+                    case T2 -> model.waitT2.update(p.getQueueWait());
+                    case RS -> model.waitRS.update(p.getQueueWait());
+                }
+            }
+            switch (currentStation) {
+                case T1 -> {
+                    model.qLenT1.update(model.qT1.size());
+                    if (model.qT1.size() > model.maxQT1) model.maxQT1 = model.qT1.size();
+                }
+                case T2 -> {
+                    model.qLenT2.update(model.qT2.size());
+                    if (model.qT2.size() > model.maxQT2) model.maxQT2 = model.qT2.size();
+                }
+                case RS -> {
+                    model.qLenRS.update(model.qRS.size());
+                    if (model.qRS.size() > model.maxQRS) model.maxQRS = model.qRS.size();
+                }
             }
 
             /* 3. Minimum dwell 5 minutes (= 5/60 hours) */
             hold(new TimeSpan(5.0 / 60.0));
+
+            /* pick up late arrivals after 5 minutes */
+            while (onBoard.size() < CAPACITY && !queue.isEmpty()) {
+                Passenger p = queue.first();
+                queue.remove(p);
+                p.boarded(presentTime().getTimeAsDouble());
+                onBoard.add(p);
+                switch (currentStation) {
+                    case T1 -> model.waitT1.update(p.getQueueWait());
+                    case T2 -> model.waitT2.update(p.getQueueWait());
+                    case RS -> model.waitRS.update(p.getQueueWait());
+                }
+            }
+            switch (currentStation) {
+                case T1 -> {
+                    model.qLenT1.update(model.qT1.size());
+                    if (model.qT1.size() > model.maxQT1) model.maxQT1 = model.qT1.size();
+                    model.dwellT1.update(presentTime().getTimeAsDouble() - arriveTime);
+                }
+                case T2 -> {
+                    model.qLenT2.update(model.qT2.size());
+                    if (model.qT2.size() > model.maxQT2) model.maxQT2 = model.qT2.size();
+                    model.dwellT2.update(presentTime().getTimeAsDouble() - arriveTime);
+                }
+                case RS -> {
+                    model.qLenRS.update(model.qRS.size());
+                    if (model.qRS.size() > model.maxQRS) model.maxQRS = model.qRS.size();
+                    model.dwellRS.update(presentTime().getTimeAsDouble() - arriveTime);
+                }
+            }
+
+            model.busOccupancy.update(onBoard.size());
 
             /* 4. Travel to next station */
             Station next = currentStation.next();
@@ -54,6 +113,10 @@ public class BusProcess extends SimProcess {
                 case T2 -> 10;
             };
             hold(new TimeSpan(travelMin / 60.0));
+            if (currentStation == Station.RS && next == Station.T1) {
+                model.roundDurations.update(presentTime().getTimeAsDouble() - lastRound);
+                lastRound = presentTime().getTimeAsDouble();
+            }
             currentStation = next;
         }
     }

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/Passenger.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/Passenger.java
@@ -22,6 +22,7 @@ public class Passenger extends Entity {
     }
 
     public Station getDestination() { return destination; }
+    public Station getOrigin() { return origin; }
 
     public void boarded(double time) { boardTime = time; }
 

--- a/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/PassengerGenerator.java
+++ b/airport-rental-sim-desmo (2)/src/main/java/com/example/airportdesmo/PassengerGenerator.java
@@ -32,6 +32,20 @@ public class PassengerGenerator extends SimProcess {
 
             Passenger p = new Passenger(model, "Pax", false, origin, dest, presentTime().getTimeAsDouble());
             myQueue.insert(p);
+            switch (origin) {
+                case T1 -> {
+                    model.qLenT1.update(model.qT1.size());
+                    if (model.qT1.size() > model.maxQT1) model.maxQT1 = model.qT1.size();
+                }
+                case T2 -> {
+                    model.qLenT2.update(model.qT2.size());
+                    if (model.qT2.size() > model.maxQT2) model.maxQT2 = model.qT2.size();
+                }
+                case RS -> {
+                    model.qLenRS.update(model.qRS.size());
+                    if (model.qRS.size() > model.maxQRS) model.maxQRS = model.qRS.size();
+                }
+            }
 
             /* Wait for next arrival */
             hold(new TimeSpan(interArrival.sample()));


### PR DESCRIPTION
## Summary
- track queue lengths, waiting time, system time, bus occupancy and durations
- implement min-5-minute dwell with boarding after the wait
- expose passenger origin for statistics
- update README with new behaviour and metrics

## Testing
- `javac -cp lib/desmoj-2.5.1e-bin.jar -d out $(find src -name '*.java')`
- `java -cp out:lib/desmoj-2.5.1e-bin.jar com.example.airportdesmo.AirportRentalSimulationDesmo`
- `java -cp out:lib/desmoj-2.5.1e-bin.jar com.example.airportdesmo.AirportRentalSimulationDesmo --hours 120`


------
https://chatgpt.com/codex/tasks/task_e_684c21c03fb0833082eaec5066495d9d